### PR TITLE
[Mc1.18.2] サーバー内でモブボトルを置くとクラッシュする

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 MobBottle
 ===
 
-Minecraft1.18.1にちょっとした小物を追加するModです。
+Minecraft1.18.2にちょっとした小物を追加するModです。
 
 ---
 
@@ -11,8 +11,8 @@ Minecraft1.18.1にちょっとした小物を追加するModです。
 
 ## 注意事項
 対応バージョン
-- Minecraft 1.18.1
-- Minecraft Forge 1.18.1-39.1.2
+- Minecraft 1.18.2
+- Minecraft Forge 1.18.2-40.1.0
   
 開発中のMODのため不具合が発生する場合があります。
 このMODを使用する場合はバックアップをとるなどして自己責任にてご使用ください。

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 
 
-version = '1.18.1-0.2'
+version = '1.18.2-0.1'
 group = 'firis.mobbottle' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'mobbottle'
 
@@ -38,7 +38,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: '1.18.1'
+    mappings channel: 'official', version: '1.18.2'
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg') // Currently, this location cannot be changed from the default.
 
@@ -151,7 +151,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.18.1-39.1.2'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency
@@ -198,4 +198,8 @@ publishing {
             url "file://${project.projectDir}/mcmodsrepo"
         }
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/firis/mobbottle/MobBottle.java
+++ b/src/main/java/firis/mobbottle/MobBottle.java
@@ -43,21 +43,21 @@ public class MobBottle
      * ブロック参照用定義
      */
 	public static class FirisBlocks {
-	    public static final RegistryObject<Block> MOB_BOTTLE = RegistryObject.of(new ResourceLocation(MODID, "mob_bottle"), ForgeRegistries.BLOCKS);
-	    public static final RegistryObject<Block> MOB_BOTTLE_EMPTY = RegistryObject.of(new ResourceLocation(MODID, "mob_bottle_empty"), ForgeRegistries.BLOCKS);		
+	    public static final RegistryObject<Block> MOB_BOTTLE = RegistryObject.create(new ResourceLocation(MODID, "mob_bottle"), ForgeRegistries.BLOCKS);
+	    public static final RegistryObject<Block> MOB_BOTTLE_EMPTY = RegistryObject.create(new ResourceLocation(MODID, "mob_bottle_empty"), ForgeRegistries.BLOCKS);		
 	}
 	/**
      * アイテム参照用定義
      */
 	public static class FirisItems {
-		public static final RegistryObject<Item> MOB_BOTTLE = RegistryObject.of(new ResourceLocation(MODID, "mob_bottle"), ForgeRegistries.ITEMS);
-		public static final RegistryObject<Item> MOB_BOTTLE_EMPTY = RegistryObject.of(new ResourceLocation(MODID, "mob_bottle"), ForgeRegistries.ITEMS);
+		public static final RegistryObject<Item> MOB_BOTTLE = RegistryObject.create(new ResourceLocation(MODID, "mob_bottle"), ForgeRegistries.ITEMS);
+		public static final RegistryObject<Item> MOB_BOTTLE_EMPTY = RegistryObject.create(new ResourceLocation(MODID, "mob_bottle"), ForgeRegistries.ITEMS);
 	}
 	/**
 	 * BlockEntityType参照用定義
 	 */
 	public static class FirisBlockEntityType {
-	    public static final RegistryObject<BlockEntityType<MobBottleBlockEntity>> BLOCK_ENTITY_TYPE = RegistryObject.of(new ResourceLocation(MODID, "mob_bottle_be"), ForgeRegistries.BLOCK_ENTITIES);
+	    public static final RegistryObject<BlockEntityType<MobBottleBlockEntity>> BLOCK_ENTITY_TYPE = RegistryObject.create(new ResourceLocation(MODID, "mob_bottle_be"), ForgeRegistries.BLOCK_ENTITIES);
 	}
 	
 	/**

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[39,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[40,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="The MIT License (MIT)"
@@ -43,7 +43,7 @@ MobBottle is a mod that allows you to capture mobs and decorate mobs.
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[39,)" #mandatory
+    versionRange="[40,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -53,6 +53,6 @@ MobBottle is a mod that allows you to capture mobs and decorate mobs.
     modId="minecraft"
     mandatory=true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-    versionRange="[1.18.1,1.19)"
+    versionRange="[1.18.2,1.19)"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
         "description": "MobBottle resources",
-        "pack_format": 8
+        "pack_format": 9
     }
 }


### PR DESCRIPTION
issueがなかったのでPull Requestsに書きました。
<details> 
  <summary>エラーログです </summary>
   ---- Minecraft Crash Report ----
// My bad.

Time: 2023/01/07 23:46
Description: Exception in server tick loop

java.lang.NoSuchFieldError: renderEntityCache
	at firis.mobbottle.common.blockentity.MobBottleBlockEntity.<init>(MobBottleBlockEntity.java:182) ~[mobbottle-1.18.2-0.1.jar%2369!/:1.18.2-0.1] {re:classloading,pl:runtimedistcleaner:A}
	at firis.mobbottle.common.block.MobBottleBlock.m_142194_(MobBottleBlock.java:85) ~[mobbottle-1.18.2-0.1.jar%2369!/:1.18.2-0.1] {re:classloading}
	at net.minecraft.world.level.chunk.LevelChunk.m_6978_(LevelChunk.java:251) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.level.Level.m_6933_(Level.java:201) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:computing_frames,pl:accesstransformer:B,re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.level.Level.m_7731_(Level.java:178) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:computing_frames,pl:accesstransformer:B,re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.item.BlockItem.m_7429_(BlockItem.java:161) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:quark.mixins.json:BlockItemMixin,pl:mixin:A}
	at net.minecraft.world.item.BlockItem.m_40576_(BlockItem.java:66) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:quark.mixins.json:BlockItemMixin,pl:mixin:A}
	at net.minecraft.world.item.BlockItem.m_6225_(BlockItem.java:46) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:quark.mixins.json:BlockItemMixin,pl:mixin:A}
	at firis.mobbottle.common.item.MobBottleBlockItem.m_6225_(MobBottleBlockItem.java:69) ~[mobbottle-1.18.2-0.1.jar%2369!/:1.18.2-0.1] {re:classloading}
	at net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(ForgeHooks.java:628) ~[forge-1.18.2-40.2.0-universal.jar%2398!/:?] {re:classloading}
	at net.minecraft.world.item.ItemStack.m_41661_(ItemStack.java:222) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,xf:fml:forge:itemstack,re:classloading,xf:fml:forge:itemstack,pl:mixin:APP:quark.mixins.json:ItemStackMixin,pl:mixin:A}
	at net.minecraft.server.level.ServerPlayerGameMode.m_7179_(ServerPlayerGameMode.java:357) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:computing_frames,re:classloading}
	at net.minecraft.server.network.ServerGamePacketListenerImpl.m_6371_(ServerGamePacketListenerImpl.java:985) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.m_5797_(ServerboundUseItemOnPacket.java:30) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:classloading}
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.m_5797_(ServerboundUseItemOnPacket.java:8) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:classloading}
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:classloading,xf:OptiFine:default}
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:classloading}
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,xf:OptiFine:default,re:computing_frames,pl:accesstransformer:B,xf:OptiFine:default,re:classloading,pl:accesstransformer:B,xf:OptiFine:default}
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,re:computing_frames,re:classloading}
	at net.minecraft.server.MinecraftServer.m_6367_(MinecraftServer.java:799) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:fastload.mixins.json:server.MinecraftServerMixin,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_6367_(MinecraftServer.java:164) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:fastload.mixins.json:server.MinecraftServerMixin,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,xf:OptiFine:default,re:computing_frames,pl:accesstransformer:B,xf:OptiFine:default,re:classloading,pl:accesstransformer:B,xf:OptiFine:default}
	at net.minecraft.server.MinecraftServer.m_129961_(MinecraftServer.java:782) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:fastload.mixins.json:server.MinecraftServerMixin,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_7245_(MinecraftServer.java:776) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:fastload.mixins.json:server.MinecraftServerMixin,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.util.thread.BlockableEventLoop.m_18701_(BlockableEventLoop.java:140) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,xf:OptiFine:default,re:computing_frames,pl:accesstransformer:B,xf:OptiFine:default,re:classloading,pl:accesstransformer:B,xf:OptiFine:default}
	at net.minecraft.server.MinecraftServer.m_130012_(MinecraftServer.java:762) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:fastload.mixins.json:server.MinecraftServerMixin,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:689) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:fastload.mixins.json:server.MinecraftServerMixin,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_177918_(MinecraftServer.java:261) ~[server-1.18.2-20220404.173914-srg.jar%2393!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:fastload.mixins.json:server.MinecraftServerMixin,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at java.lang.Thread.run(Thread.java:833) [?:?] {}


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- System Details --
Details:
	Minecraft Version: 1.18.2
	Minecraft Version ID: 1.18.2
	Operating System: Windows 11 (amd64) version 10.0
	Java Version: 17.0.5, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode, sharing), Oracle Corporation
	Memory: 7385848848 bytes (7043 MiB) / 8589934592 bytes (8192 MiB) up to 8589934592 bytes (8192 MiB)
	CPUs: 20
	Processor Vendor: GenuineIntel
	Processor Name: 12th Gen Intel(R) Core(TM) i7-12700
	Identifier: Intel64 Family 6 Model 151 Stepping 2
	Microarchitecture: unknown
	Frequency (GHz): 2.11
	Number of physical packages: 1
	Number of physical CPUs: 12
	Number of logical CPUs: 20
	Graphics card #0 name: NVIDIA GeForce RTX 3060
	Graphics card #0 vendor: NVIDIA (0x10de)
	Graphics card #0 VRAM (MB): 4095.00
	Graphics card #0 deviceId: 0x2504
	Graphics card #0 versionInfo: DriverVersion=31.0.15.2225
	Memory slot #0 capacity (MB): 16384.00
	Memory slot #0 clockSpeed (GHz): 3.20
	Memory slot #0 type: DDR4
	Memory slot #1 capacity (MB): 16384.00
	Memory slot #1 clockSpeed (GHz): 3.20
	Memory slot #1 type: DDR4
	Virtual memory max (MB): 50941.42
	Virtual memory used (MB): 37855.17
	Swap memory total (MB): 18432.00
	Swap memory used (MB): 584.65
	JVM Flags: 8 total; -Xms8G -Xmx8G -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=20 -XX:G1ReservePercent=20 -XX:MaxGCPauseMillis=30 -XX:G1HeapRegionSize=32M
	Server Running: true
	Player Count: 1 / 20; [ServerPlayer['Hyakilia'/161, l='ServerLevel[world]', x=10.59, y=65.00, z=-22.96]]
	Data Packs: vanilla, mod:blue_skies (incompatible), mod:fastload (incompatible), mod:torchslabmod (incompatible), mod:jei (incompatible), mod:sophisticatedcore (incompatible), mod:villagernames, mod:clumps (incompatible), mod:journeymap, mod:naturescompass (incompatible), mod:namepain (incompatible), mod:yungsapi, mod:sophisticatedbackpacks (incompatible), mod:fakename (incompatible), mod:balm (incompatible), mod:mobbottle, mod:carryon (incompatible), mod:jeresources (incompatible), mod:forge, mod:stackrefill, mod:dcintegration (incompatible), mod:forgottenrecipes (incompatible), mod:structure_gel, mod:ironchest, mod:logprot (incompatible), mod:farmersdelight (incompatible), mod:torchmaster (incompatible), mod:morevillagers, mod:syp (incompatible), mod:mmlib (incompatible), mod:curios (incompatible), mod:patchouli (incompatible), mod:ars_nouveau, mod:collective, mod:camera (incompatible), mod:autoreglib (incompatible), mod:quark (incompatible), mod:sit (incompatible), mod:oreexcavation, mod:hardcorerevival (incompatible), mod:usefulhats, mod:theabyss, mod:cfm, mod:aiimprovements (incompatible), mod:chimes (incompatible), mod:fallingtree, mod:enchantwithmob, mod:bwncr (incompatible), mod:bettermineshafts, mod:tofucraft, mod:voidtotem (incompatible), mod:appleskin (incompatible), mod:rottencreatures (incompatible)
	World Generation: Experimental
	Is Modded: Definitely; Server brand changed to 'forge'
	Type: Dedicated Server (map_server.txt)
	ModLauncher: 9.1.3+9.1.3+main.9b69c82a
	ModLauncher launch target: forgeserver
	ModLauncher naming: srg
	ModLauncher services: 
		 mixin PLUGINSERVICE 
		 eventbus PLUGINSERVICE 
		 slf4jfixer PLUGINSERVICE 
		 object_holder_definalize PLUGINSERVICE 
		 runtime_enum_extender PLUGINSERVICE 
		 capability_token_subclass PLUGINSERVICE 
		 accesstransformer PLUGINSERVICE 
		 runtimedistcleaner PLUGINSERVICE 
		 mixin TRANSFORMATIONSERVICE 
		 OptiFine TRANSFORMATIONSERVICE 
		 fml TRANSFORMATIONSERVICE 
	FML Language Providers: 
		minecraft@1.0
		lowcodefml@null
		javafml@null
	Mod List: 
		blue_skies-1.18.2-1.3.12.jar                      |Blue Skies                    |blue_skies                    |1.3.12              |DONE      |Manifest: NOSIGNATURE
		Fastload-Reforged-2.6.9+1.18.2.jar                |Fastload                      |fastload                      |2.6.9+1.18.2        |DONE      |Manifest: NOSIGNATURE
		torchslabmod-1.18.1_v1.7.5.jar                    |Torch Slab Mod                |torchslabmod                  |1.7.5               |DONE      |Manifest: NOSIGNATURE
		jei-1.18.2-forge-10.2.1.283.jar                   |Just Enough Items             |jei                           |10.2.1.283          |DONE      |Manifest: NOSIGNATURE
		sophisticatedcore-1.18.2-0.5.36.199.jar           |Sophisticated Core            |sophisticatedcore             |1.18.2-0.5.36.199   |DONE      |Manifest: NOSIGNATURE
		villagernames_1.18.2-4.3.jar                      |Villager Names                |villagernames                 |4.3                 |DONE      |Manifest: NOSIGNATURE
		Clumps-forge-1.18.2-8.0.0+17.jar                  |Clumps                        |clumps                        |8.0.0+17            |DONE      |Manifest: NOSIGNATURE
		journeymap-1.18.2-5.9.0-forge.jar                 |Journeymap                    |journeymap                    |5.9.0               |DONE      |Manifest: NOSIGNATURE
		NaturesCompass-1.18.2-1.9.7-forge.jar             |Nature's Compass              |naturescompass                |1.18.2-1.9.7-forge  |DONE      |Manifest: NOSIGNATURE
		namepain-1.4.1+forge-1.18.x.jar                   |Name Pain                     |namepain                      |1.4.1               |DONE      |Manifest: NOSIGNATURE
		YungsApi-1.18.2-Forge-2.2.7.jar                   |YUNG's API                    |yungsapi                      |1.18.2-Forge-2.2.7  |DONE      |Manifest: NOSIGNATURE
		sophisticatedbackpacks-1.18.2-3.18.40.773.jar     |Sophisticated Backpacks       |sophisticatedbackpacks        |1.18.2-3.18.40.773  |DONE      |Manifest: NOSIGNATURE
		fakename-1.18.1-1.3.5.jar                         |Fakename                      |fakename                      |1.3.5               |DONE      |Manifest: NOSIGNATURE
		balm-3.2.1+0.jar                                  |Balm                          |balm                          |3.2.1+0             |DONE      |Manifest: NOSIGNATURE
		mobbottle-1.18.2-0.1.jar                          |MobBottle                     |mobbottle                     |1.18.2-0.1          |DONE      |Manifest: NOSIGNATURE
		carryon-1.18.2-1.17.0.8.jar                       |Carry On                      |carryon                       |1.17.0.8            |DONE      |Manifest: NOSIGNATURE
		JustEnoughResources-1.18.2-0.14.1.171.jar         |Just Enough Resources         |jeresources                   |0.14.1.171          |DONE      |Manifest: NOSIGNATURE
		forge-1.18.2-40.2.0-universal.jar                 |Forge                         |forge                         |40.2.0              |DONE      |Manifest: 84:ce:76:e8:45:35:e4:0e:63:86:df:47:59:80:0f:67:6c:c1:5f:6e:5f:4d:b3:54:47:1a:9f:7f:ed:5e:f2:90
		stackrefill_1.18.2-3.2.jar                        |Stack Refill                  |stackrefill                   |3.2                 |DONE      |Manifest: NOSIGNATURE
		dcintegration-forge-2.5.0-1.18.2.jar              |Discord Integration           |dcintegration                 |2.5.0               |DONE      |Manifest: NOSIGNATURE
		forgottenrecipes-forge-1.18.1-1.0.0.jar           |Forgotten Recipes             |forgottenrecipes              |1.18.1-1.0.0        |DONE      |Manifest: NOSIGNATURE
		structure_gel-1.18.2-2.4.7.jar                    |Structure Gel API             |structure_gel                 |2.4.7               |DONE      |Manifest: NOSIGNATURE
		ironchest-1.18.2-13.2.11.jar                      |Iron Chests                   |ironchest                     |1.18.2-13.2.11      |DONE      |Manifest: NOSIGNATURE
		server-1.18.2-20220404.173914-srg.jar             |Minecraft                     |minecraft                     |1.18.2              |DONE      |Manifest: NOSIGNATURE
		logprot-1.18.2-1.6.jar                            |Logprot                       |logprot                       |1.4                 |DONE      |Manifest: NOSIGNATURE
		FarmersDelight-1.18.2-1.2.0.jar                   |Farmer's Delight              |farmersdelight                |1.18.2-1.2.0        |DONE      |Manifest: NOSIGNATURE
		torchmaster-18.1.0.jar                            |Torchmaster                   |torchmaster                   |18.1.0              |DONE      |Manifest: NOSIGNATURE
		morevillagers-forge-1.18.2-3.3.2.jar              |More Villagers                |morevillagers                 |3.3.2               |DONE      |Manifest: NOSIGNATURE
		SaveYourPets-1.18-1.0.0.7.jar                     |Save Your Pets                |syp                           |1.0.0.7             |DONE      |Manifest: NOSIGNATURE
		rottencreatures-forge-1.18.2-1.0.0.jar            |Rotten Creatures              |rottencreatures               |1.0.0               |DONE      |Manifest: NOSIGNATURE
		mmlib-1.1.3-1.18.2.jar                            |Mysterious Mountain Lib       |mmlib                         |1.1.3-1.18.2        |DONE      |Manifest: NOSIGNATURE
		curios-forge-1.18.2-5.0.7.1.jar                   |Curios API                    |curios                        |1.18.2-5.0.7.1      |DONE      |Manifest: NOSIGNATURE
		Patchouli-1.18.2-71.1.jar                         |Patchouli                     |patchouli                     |1.18.2-71.1         |DONE      |Manifest: NOSIGNATURE
		ars_nouveau-1.18.2-2.8.0.jar                      |Ars Nouveau                   |ars_nouveau                   |2.8.0               |DONE      |Manifest: NOSIGNATURE
		collective-1.18.2-5.45.jar                        |Collective                    |collective                    |5.45                |DONE      |Manifest: NOSIGNATURE
		camera-1.18.2-1.0.5.jar                           |Camera Mod                    |camera                        |1.18.2-1.0.5        |DONE      |Manifest: NOSIGNATURE
		AutoRegLib-1.7-53.jar                             |AutoRegLib                    |autoreglib                    |1.7-53              |DONE      |Manifest: NOSIGNATURE
		Quark-3.2-358.jar                                 |Quark                         |quark                         |3.2-358             |DONE      |Manifest: NOSIGNATURE
		sit-1.18.2-1.3.2.jar                              |Sit                           |sit                           |1.3.2               |DONE      |Manifest: NOSIGNATURE
		OreExcavation-1.10.162.jar                        |OreExcavation                 |oreexcavation                 |1.10.162            |DONE      |Manifest: NOSIGNATURE
		hardcorerevival-forge-1.18.2-8.0.1.jar            |Hardcore Revival              |hardcorerevival               |0.0NONE             |DONE      |Manifest: NOSIGNATURE
		usefulhats-1.18.2-2.0.2.0.jar                     |Useful Hats                   |usefulhats                    |1.18.2-2.0.2.0      |DONE      |Manifest: NOSIGNATURE
		TheAbyss2+2.2.3-4-a+1.18.2.jar                    |TheAbyss                      |theabyss                      |2.2.34              |DONE      |Manifest: NOSIGNATURE
		cfm-7.0.0-pre29-1.18.2.jar                        |MrCrayfish's Furniture Mod    |cfm                           |7.0.0-pre29         |DONE      |Manifest: NOSIGNATURE
		appleskin-forge-mc1.18.2-2.4.1.jar                |AppleSkin                     |appleskin                     |2.4.1+mc1.18.2      |DONE      |Manifest: NOSIGNATURE
		AI-Improvements-1.18.2-0.5.2.jar                  |AI-Improvements               |aiimprovements                |0.5.2               |DONE      |Manifest: NOSIGNATURE
		Chimes-1.1.2-1.18.2.jar                           |Chimes                        |chimes                        |1.1.2               |DONE      |Manifest: NOSIGNATURE
		FallingTree-1.18.2-3.5.4.jar                      |FallingTree                   |fallingtree                   |3.5.4               |DONE      |Manifest: 3c:8e:df:6c:df:a6:2a:9f:af:64:ea:04:9a:cf:65:92:3b:54:93:0e:96:50:b4:52:e1:13:42:18:2b:ae:40:29
		enchantwithmob-1.18.2-4.2.1.jar                   |Enchant With Mob              |enchantwithmob                |1.18.2-4.2.1        |DONE      |Manifest: NOSIGNATURE
		bwncr-3.13.21.jar                                 |Bad Wither No Cookie Reloaded |bwncr                         |3.13.21             |DONE      |Manifest: NOSIGNATURE
		YungsBetterMineshafts-1.18.2-Forge-2.2.jar        |YUNG's Better Mineshafts      |bettermineshafts              |1.18.2-Forge-2.2    |DONE      |Manifest: NOSIGNATURE
		TofuCraftReload-1.18.2-1.0.2.2.jar                |TofuCraftReload               |tofucraft                     |1.18.2-1.0.2.2      |DONE      |Manifest: NOSIGNATURE
		voidtotem-forge-1.18.2-1.3.1.jar                  |Void Totem                    |voidtotem                     |1.18.2-1.3.1        |DONE      |Manifest: NOSIGNATURE
	Crash Report UUID: f96692f5-1e76-4914-937f-fb94ac83a804
	FML: 40.2
	Forge: net.minecraftforge:40.2.0
</details>