### PR TITLE
マルチプレイ時にサーバーがクラッシュする不具合の修正 (mc1.18.2)

### DIFF
--- a/src/main/java/firis/mobbottle/common/blockentity/MobBottleBlockEntity.java
+++ b/src/main/java/firis/mobbottle/common/blockentity/MobBottleBlockEntity.java
@@ -3,6 +3,7 @@ package firis.mobbottle.common.blockentity;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.minecraftforge.fml.DistExecutor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import firis.mobbottle.MobBottle;
@@ -54,6 +55,11 @@ public class MobBottleBlockEntity extends BlockEntity {
 	
 	public MobBottleBlockEntity(BlockPos p_155229_, BlockState p_155230_) {
 		super(MobBottle.FirisBlockEntityType.BLOCK_ENTITY_TYPE.get(), p_155229_, p_155230_);
+		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () ->  () -> {
+			renderEntityCache = null;
+			isRenderEntityCache = false;
+			renderEntityCacheMap = new HashMap<>();
+		});
 	}
 	
 	/**
@@ -180,10 +186,10 @@ public class MobBottleBlockEntity extends BlockEntity {
 	 * 描画用Entityキャッシュ
 	 */
 	@OnlyIn(Dist.CLIENT)
-	protected Entity renderEntityCache = null;
+	protected Entity renderEntityCache;
 	
 	@OnlyIn(Dist.CLIENT)
-	protected boolean isRenderEntityCache = false;
+	protected boolean isRenderEntityCache;
 	
 	/**
 	 * 描画用Entity取得
@@ -239,12 +245,11 @@ public class MobBottleBlockEntity extends BlockEntity {
 	// BlockEntityWithoutLevelRenderer対応
 	//**************************************************
 	@OnlyIn(Dist.CLIENT)
-	private Map<CompoundTag, Entity> renderEntityCacheMap = new HashMap<>();
+	private Map<CompoundTag, Entity> renderEntityCacheMap;
 	
 	/**
 	 * アイテム描画に必要な情報を設定する
 	 * @param stack
-	 * @param direction
 	 */
 	@SuppressWarnings("resource")
 	@OnlyIn(Dist.CLIENT)


### PR DESCRIPTION
# 概要
マルチプレイ時に、モブボトルを設置した際にサーバーがクラッシュする不具合が見つかりました。
このプルリクエストには、その不具合の修正が含まれています。

# バグについて
Pull Request #2  にて報告されているものと同じものです。
念の為こちらにも記載しておきます。

## バグの概要
マルチプレイ時、モブボトルを設置すると、サーバーがクラッシュする。

## 再現手順
1. MobBottle mod が導入されているマルチプレイサーバーにログインする
2. モブボトルを、`Shift + 右クリック` で適当な場所に設置する
3. サーバーがクラッシュする

## 確認したバージョン
- [MobBottle ver1.18.2-0.1](https://github.com/firis-games/MobBottle/releases/tag/ver1.18.2-0.1)
- [MobBottle ver1.20.1-0.1](https://github.com/firis-games/MobBottle/releases/tag/ver1.20.1-0.1)
実際に動作させて確認したバージョンは上記２つのみですが、後述の理由から、1.19.xでも発生するものと思われます。

## ログ
<details>
<summary>クラッシュログ (抜粋)</summary>

```
---- Minecraft Crash Report ----
// Daisy, daisy...

Time: 2023/11/29 2:28
Description: Exception in server tick loop

java.lang.NoSuchFieldError: renderEntityCache
	at firis.mobbottle.common.blockentity.MobBottleBlockEntity.<init>(MobBottleBlockEntity.java:182) ~[mobbottle-1.18.2-0.1.jar%2340!/:1.18.2-0.1] {re:classloading,pl:runtimedistcleaner:A}
	at firis.mobbottle.common.block.MobBottleBlock.m_142194_(MobBottleBlock.java:85) ~[mobbottle-1.18.2-0.1.jar%2340!/:1.18.2-0.1] {re:classloading}
	at net.minecraft.world.level.chunk.LevelChunk.m_6978_(LevelChunk.java:251) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.world.level.Level.m_6933_(Level.java:201) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.level.Level.m_7731_(Level.java:178) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.world.item.BlockItem.m_7429_(BlockItem.java:161) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.world.item.BlockItem.m_40576_(BlockItem.java:66) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.world.item.BlockItem.m_6225_(BlockItem.java:46) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at firis.mobbottle.common.item.MobBottleBlockItem.m_6225_(MobBottleBlockItem.java:69) ~[mobbottle-1.18.2-0.1.jar%2340!/:1.18.2-0.1] {re:classloading}
	at net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(ForgeHooks.java:628) ~[forge-1.18.2-40.2.14-universal.jar%2347!/:?] {re:classloading}
	at net.minecraft.world.item.ItemStack.m_41661_(ItemStack.java:222) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,xf:fml:forge:itemstack}
	at net.minecraft.server.level.ServerPlayerGameMode.m_7179_(ServerPlayerGameMode.java:357) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.server.network.ServerGamePacketListenerImpl.m_6371_(ServerGamePacketListenerImpl.java:985) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.m_5797_(ServerboundUseItemOnPacket.java:30) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.m_5797_(ServerboundUseItemOnPacket.java:8) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading}
	at net.minecraft.server.MinecraftServer.m_6367_(MinecraftServer.java:799) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_6367_(MinecraftServer.java:164) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_129961_(MinecraftServer.java:782) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_7245_(MinecraftServer.java:776) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_130012_(MinecraftServer.java:761) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:689) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_177918_(MinecraftServer.java:261) ~[server-1.18.2-20220404.173914-srg.jar%2342!/:?] {re:classloading,pl:accesstransformer:B}
	at java.lang.Thread.run(Thread.java:833) [?:?] {}

```
</details>

## 不具合の原因
サーバーのクラッシュは、`MobBottleBlockEntity` のインスタンス作成時に、存在しないメンバ `renderEntityCache` に対してアクセスをしようとして発生しています。
`firis/mobbottle/common/blockentity/MobBottleBlockEntity.java` にて、以下のようなコードがあります。
``` java
	/**
	 * 描画用Entityキャッシュ
	 */
	@OnlyIn(Dist.CLIENT)
	protected Entity renderEntityCache = null;
```
こちらのアノテーションコードですが、サーバー環境において、宣言そのものはなくなるものの、 **そのメンバに対しての初期化処理は残ってしまう** という仕様になっているようでした。
そのため、インスタンス作成時にこのメンバに対しての初期化が実行されることとなり、その結果、宣言のないメンバに対してアクセスが発生しているようです。

## 影響を受けるバージョン
対象のソースコードは、 3135c0f49beae266109e8524134c5443d32f9f01 (`forge-1.18.1-39.1.2-mdk対応`) から含まれていることから、影響があるバージョンは、  
**1.18.2 〜 1.20.1 ( 11/30時点での最新版 )**  
までと思われます。
対象ソースの含まれていない 1.16.5 までのバージョンに関しては、このソース起因の不具合はないものと思われます。

# 対処方法
1. `@OnlyIn` で宣言・初期化を行っているメンバ変数を、宣言のみとする
2. 上記の変数は、コンストラクタにて、 `DistExecutor` を使用してクライアント環境でのみ初期化を実行する

# その他
ソースコード内で、他に`@OnlyIn` を使用した変数宣言・初期化が他にないか調査しましたが、当該の記述は今回修正を行ったソース内にのみ存在しているようでした。